### PR TITLE
Connolly fix

### DIFF
--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -2055,14 +2055,15 @@ double dsigCC(double E, int CCmode, int type,int AntiNu )
 {
   AntiNu=int(abs(AntiNu-1)/2);//return AntiNu to be like a bool
   
-  double C0;
-  double C1;
-  double C2;
-  double C3;
-  double C4;
-  
-  if(CCmode == 0){
+  if(CCmode == 0){ // CTW model using equation 7 and Table 3 from arXiv:1102.0691
       double log10_E_GeV = log10(E);
+  
+      double C0;
+      double C1;
+      double C2;
+      double C3;
+      double C4;
+  
       if(!AntiNu){
           C0 = -1.826;
           C1 = -17.31;
@@ -2081,11 +2082,97 @@ double dsigCC(double E, int CCmode, int type,int AntiNu )
       
       return pow(10, C1 + C2*log(log10_E_GeV-C0) + C3*pow(log(log10_E_GeV-C0), 2) + C4/log(log10_E_GeV-C0));
   }
-  
-  else{
-      std::cout << "No Parameterization Selected!" << std::endl;
-      return 0;
-  }   
+  else if(CCmode < 6) {
+
+      // The value below determines when we switch from the parameterizations 
+      // of the neutrino cross sections at ultra-high energis (e.g. CTTW standard values) 
+      // to the cross sections to the Ghandi parameterization. These transitions were determined
+      // using the parameterization made for this code. They are likely a bit different if the user 
+      // switches the cross section to the upper or lower cross section models. 
+
+      double E_switch = 2.00e6;  // GeV
+
+      // If the energy is below E_sigma_switch, set CCmode to the Ghandi cross-section.
+      // If the particle is a neutrino, AntiNu = 0 and the cross-section is set to the
+      // the Ghandi model for neutrinos. If it is an anti-neutrino, AntiNu=1 and the
+      // cross-section is set to the Ghdni model for anti-neutrinos.
+
+      if( E < E_switch )
+      {
+        CCmode = 4 + AntiNu;
+      }
+
+      vector<double> p(4); 
+      if(CCmode==1) { // Connolly+, 2011 middle model (ARW's parametrization)
+          p = { -5.35400180e+01,   2.65901551e+00, -1.14017685e-01,   1.82495442e-03};
+      }
+      else if(CCmode==2) { // Connolly+, 2011 lower model (ARW's parametrization)
+          p = {-4.26355014e+01,   4.89151126e-01,   2.94975025e-02,  -1.32969832e-03};
+      }
+      else if(CCmode==3) { // Connolly+, 2011 upper model (ARW's parametrization)
+          p = {-5.31078363e+01,   2.72995742e+00,  -1.28808188e-01,   2.36800261e-03};
+      }
+      else if(CCmode==4) { // Gandhi, Quigg, Reno 1995 Neutrino cross section
+          p = { -6.24043607e+01,   4.21769574e+00, -2.06814586e-01,   3.70730061e-03};
+      }
+      else { // Gandhi, Quigg, Reno 1995 Anti-Neutrino cross section
+          p = { -6.43574494e+01,   4.41740442e+00, -2.10856220-01,   3.65724741e-03};
+      }
+
+      double log10_E_eV = log10(E)+9.;
+      double f=0.;
+      for (int ii = 0 ; ii<4; ii++)
+      {
+        f += p[ii]*pow(log10_E_eV,ii);
+      }
+
+      f = pow(10,f);
+      return f;
+
+        
+      // Unused parameterizations
+
+      //  double l1=log10(E);
+      //  double l2=l1*l1;
+      //  double l3=l2*l1;
+      //  double l4=l3*l1;
+      //  double l5=l4*l1;
+      //  double l6=l5*l1;
+      //  double l7=l6*l1;
+      //  f=pCC0+pCC1*l1+pCC2*l2+pCC3*l3+pCC4*l4+pCC5*l5+pCC6*l6+pCC7*l7;
+      
+      //      f = 6.37994*pow(E,0.355991)*1e-36;
+      
+      /* CKMT */
+      //      f = (-36.3345965603+7.14693605311*pow(E,0.293313250614))*1.e-36;
+      
+      /* ALLM */
+      // H. Abramowicz et al., Phys. Lett. B 269, 465 (1991);
+      // H. Abramowicz and A. Levy, hep-ph/9712415.
+      //  f = (-280.544665122+10.3452620208*pow(E,0.317119535055))*1.e-36;
+      
+      /* ASW */   // Saturation of pdfs
+                  // N. Armesto et al., Phys. Rev. D 77, 013001 (2008).
+                  // N. Armesto et al., Phys. Rev. Lett. 94, 022002 (2005).
+                  //      f = (-799.252409182+52.4932827684*pow(E,0.244551044541))*1.e-36;
+      
+      /* Sarkar */  // Default model used in Auger
+                      // A. Cooper-Sarkar and S. Sarkar, JHEP 0801, 075 (2008).
+                      // Amanda Cooper-Sarkar, Philipp Mertsch, Subir Sarkar. JHEP 08, 042 (2011).
+                      //      f = (-649.265343982+26.4437052803*pow(E,0.296160447336))*1.e-36;
+      
+      // Sarkar model (Yann's parametrization)
+      //    double AS=-0.391641;
+      //    double BS=0.635232;
+      //    double CS=-0.0158144;
+      //    f= (pow(10,AS+BS*log10(E)+CS*pow(log10(E),2)))*1.e-36;
+            
+          
+ 
+  }
+ 
+  std::cout << "No Parameterization Selected!" << std::endl;
+  return 0;
 }
 
 
@@ -2093,14 +2180,15 @@ double dsigNC(double E, int CCmode, int type,int AntiNu )
 {
   AntiNu=int(abs(AntiNu-1)/2);//return AntiNu to be like a bool
   
-  double C0;
-  double C1;
-  double C2;
-  double C3;
-  double C4;
-  if(CCmode == 0){
+  if(CCmode == 0){ // CTW model using equation 7 and Table 3 from arXiv:1102.0691
       double log10_E_GeV = log10(E);
-      //std::cout<<log10_E_GeV<<std::endl;
+  
+      double C0;
+      double C1;
+      double C2;
+      double C3;
+      double C4;
+      
       if(!AntiNu){
           C0 = -1.826;
           C1 = -17.31;
@@ -2119,11 +2207,56 @@ double dsigNC(double E, int CCmode, int type,int AntiNu )
 
       return pow(10, C1 + C2*log(log10_E_GeV-C0) + C3*pow(log(log10_E_GeV-C0), 2) + C4/log(log10_E_GeV-C0));
   }
+  else if(CCmode < 6) {
+
+      // The value below determines when we switch from the parameterizations 
+      // of the neutrino cross sections at ultra-high energis (e.g. CTTW standard values) 
+      // to the cross sections to the Ghandi parameterization. These transitions were determined
+      // using the parameterization made for this code. They are likely a bit different if the user 
+      // switches the cross section to the upper or lower cross section models. 
+      double E_switch = 2.00e6;  // GeV
+
+      // If the energy is below E_sigma_switch, set CCmode to the Ghandi cross-section.
+      // If the particle is a neutrino, AntiNu = 0 and the cross-section is set to the
+      // the Ghandi model for neutrinos. If it is an anti-neutrino, AntiNu=1 and the
+      // cross-section is set to the Ghdni model for anti-neutrinos.
+
+      if( E < E_switch )
+      {
+        CCmode = 4 + AntiNu;
+      }
+
+      vector<double> p(4);
+      if(CCmode==1) { // Connolly+, 2011 middle model (ARW's parametrization)
+        p = { -5.41463399e+01,   2.65465169e+00,  -1.11848922e-01,   1.75469643e-03};
+      }
+      else if(CCmode==2) { // Connolly+, 2011 lower model (ARW's parametrization)
+        p = {-4.42377028e+01, 7.07758518e-01, 1.55925146e-02, -1.02484763e-03};
+      }
+      else if(CCmode = 3) { // Connolly+, 2011 upper model (ARW's parametrization)
+        p = {-5.36713302e+01,   2.72528813e+00,  -1.27067769e-01,   2.31235293e-03};
+      } 
+      else if(CCmode==4) { // Gandhi, Quigg, Reno 1995 Neutrino cross section
+        p = { -6.33753554e+01,   4.26790713e+00,  -2.07426844e-01,   3.68501726e-03};
+      }
+      else { // Gandhi, Quigg, Reno 1995 Anti-Neutrino cross section
+        p = { -6.33697437e+01,   4.11592385e+00,  -1.90600183e-01,   3.22478095e-03};
+      }
+
+      double log10_E_eV = log10(E)+9.;
+      double f=0.; 
+      for (int ii = 0 ; ii<4; ii++){
+        f += p[ii]*pow(log10_E_eV,ii);
+      }
+
+      f = pow(10,f);
+      
+      return f;
+  }  
   
-  else{
-      std::cout << "No Parameterization Selected!" << std::endl;
-      return 0;
-  }   
+  std::cout << "No Parameterization Selected!" << std::endl;
+  return 0;
+
 }
 
 // ###################################################

--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -1634,7 +1634,7 @@ int main(int argc, char **argv)
 int still_going_towards_det(double * pos, double * traj_vec, double det_rad, double det_depth)
 {
   //check if in volume
-  bool in_vol = in_volume(pos[0],pos[1],pos[2],det_rad,det_depth);
+  bool in_vol = in_volume(pos[0], pos[1], pos[2], det_rad,det_depth);
 
   if (in_vol) return 1;
   else
@@ -1644,18 +1644,17 @@ int still_going_towards_det(double * pos, double * traj_vec, double det_rad, dou
     //double elevation_angle = tan2(pos[2],r);
 
     //above going up
-    if(pos[2]>R0 && traj_vec[2]>0) return 2;
+    if(pos[2] > R0 && traj_vec[2] > 0) return 2;
 
     //below going down
-    if(pos[2]<R0-det_depth*1e5 && traj_vec[2]<0) return 2;
+    if(pos[2] < R0-det_depth*1e5 && traj_vec[2] < 0) return 3;
 
     //outside going away from center
-    double r_dot_traj = pos[0]*traj_vec[0]+pos[1]*traj_vec[1]+pos[2]*traj_vec[2];
-    if(r_dot_traj>0) return 2;
+    double r_dot_traj = pos[0]*traj_vec[0]+pos[1]*traj_vec[1]; //bad bug -> +pos[2]*traj_vec[2];
+    if(r_dot_traj > 1e-9) return 4;
 
     //made it here is is still heading to the det
     return 0;
-    
   }
 }
 

--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -94,6 +94,7 @@ Earth *terra = new Earth(0.0, 2.6);
 //#############################################################
 int main(int argc, char **argv)
 {
+ 
   double time_start=time(NULL); //set timing variable
   load_config(); 
   continuous_loss_prop cont;
@@ -2325,7 +2326,7 @@ double dsigCC(double E, int CCmode, int type,int AntiNu )
           C4 = -17.72;
       }
       
-      return pow(10, C1 + C2*log(E-C0) + pow(C3*log(E-C0), 2) + C4/log(E-C0));
+      return pow(10, C1 + C2*log(log10_E_GeV-C0) + C3*pow(log(log10_E_GeV-C0), 2) + C4/log(log10_E_GeV-C0));
   }
   
   else{
@@ -2346,6 +2347,7 @@ double dsigNC(double E, int CCmode, int type,int AntiNu )
   double C4;
   if(CCmode == 0){
       double log10_E_GeV = log10(E);
+      std::cout<<log10_E_GeV<<std::endl;
       if(!AntiNu){
           C0 = -1.826;
           C1 = -17.31;
@@ -2361,8 +2363,8 @@ double dsigNC(double E, int CCmode, int type,int AntiNu )
           C3 = 1.569;
           C4 = -18.30;
       }
-      
-      return pow(10, C1 + C2*log(E-C0) + pow(C3*log(E-C0), 2) + C4/log(E-C0));
+
+      return pow(10, C1 + C2*log(log10_E_GeV-C0) + C3*pow(log(log10_E_GeV-C0), 2) + C4/log(log10_E_GeV-C0));
   }
   
   else{

--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -387,8 +387,8 @@ int main(int argc, char **argv)
   ofstream out_trajs(out_trajectories_name.c_str());
 
   #ifdef DBG
-    printf("saving emerging particles to %s\n",nameEnergies);
-    printf("saving events to %s\n",nameEvents);
+    printf("saving emerging particles to %s\n",nameEnergies.c_str());
+    printf("saving events to %s\n",nameEvents.c_str());
   #endif
   outEvents<<"rad [km]: "<<config.ice_det_rad<<", depth [km]: "<<config.ice_det_depth<<", n_nu_throws per file: "<<input_num<<endl;
   

--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -2296,149 +2296,79 @@ double dsigGR(double E, int type, int AntiNu)
 
   return cs;
 }
+
 double dsigCC(double E, int CCmode, int type,int AntiNu )
 {
-  
-  double f=0.;
-  double p[4];
-  
   AntiNu=int(abs(AntiNu-1)/2);//return AntiNu to be like a bool
-  // The value below determines when we switch from the parameterizations 
-  // of the neutrino cross sections at ultra-high energis (e.g. CTTW standard values) 
-  // to the cross sections to the Ghandi parameterization. These transitions were determined
-  // using the parameterization made for this code. They are likely a bit different if the user 
-  // switches the cross section to the upper or lower cross section models. 
-
-  double E_switch = 2.00e6;  // GeV
-
-  // If the energy is below E_sigma_switch, set CCmode to the Ghandi cross-section.
-  // If the particle is a neutrino, AntiNu = 0 and the cross-section is set to the
-  // the Ghandi model for neutrinos. If it is an anti-neutrino, AntiNu=1 and the
-  // cross-section is set to the Ghdni model for anti-neutrinos.
-
-  if( E < E_switch ){
-  CCmode = 3 + AntiNu;
-  } 
-
-  // Connolly+, 2011 middle model (ARW's parametrization)
-  double p0[4] = { -5.35400180e+01,   2.65901551e+00, -1.14017685e-01,   1.82495442e-03};
-  // Connolly+, 2011 lower model (ARW's parametrization)
-  double p1[4] = {-4.26355014e+01,   4.89151126e-01,   2.94975025e-02,  -1.32969832e-03};
-  // Connolly+, 2011 upper model (ARW's parametrization)
-  double p2[4] = {-5.31078363e+01,   2.72995742e+00,  -1.28808188e-01,   2.36800261e-03};
-
-  // Gandhi, Quigg, Reno 1995 Neutrino cross section
-  double p3[4] = { -6.24043607e+01,   4.21769574e+00, -2.06814586e-01,   3.70730061e-03};
-  // Gandhi, Quigg, Reno 1995 Anti-Neutrino cross section
-  double p4[4] = { -6.43574494e+01,   4.41740442e+00, -2.10856220-01,   3.65724741e-03};
-
-  double log10_E_eV = log10(E)+9.;
-  for (int ii = 0 ; ii<4; ii++)
-  {
-    if(CCmode==0) p[ii] = p0[ii];
-    if(CCmode==1) p[ii] = p1[ii];
-    if(CCmode==2) p[ii] = p2[ii];
-    if(CCmode==3) p[ii] = p3[ii];
-    if(CCmode==4) p[ii] = p4[ii];
-
-    f += p[ii]*pow(log10_E_eV,ii);
-  }
-
-  f = pow(10,f);
-  return f;
-
-    
-        
-  // 	double l1=log10(E);
-  // 	double l2=l1*l1;
-  // 	double l3=l2*l1;
-  // 	double l4=l3*l1;
-  // 	double l5=l4*l1;
-  // 	double l6=l5*l1;
-  // 	double l7=l6*l1;
-  // 	f=pCC0+pCC1*l1+pCC2*l2+pCC3*l3+pCC4*l4+pCC5*l5+pCC6*l6+pCC7*l7;
   
-  //      f = 6.37994*pow(E,0.355991)*1e-36;
+  double C0;
+  double C1;
+  double C2;
+  double C3;
+  double C4;
   
-  /* CKMT */
-  //      f = (-36.3345965603+7.14693605311*pow(E,0.293313250614))*1.e-36;
-  
-  /* ALLM */
-  // H. Abramowicz et al., Phys. Lett. B 269, 465 (1991);
-  // H. Abramowicz and A. Levy, hep-ph/9712415.
-  //	f = (-280.544665122+10.3452620208*pow(E,0.317119535055))*1.e-36;
-  
-  /* ASW */   // Saturation of pdfs
-              // N. Armesto et al., Phys. Rev. D 77, 013001 (2008).
-              // N. Armesto et al., Phys. Rev. Lett. 94, 022002 (2005).
-              //      f = (-799.252409182+52.4932827684*pow(E,0.244551044541))*1.e-36;
-  
-  /* Sarkar */  // Default model used in Auger
-                  // A. Cooper-Sarkar and S. Sarkar, JHEP 0801, 075 (2008).
-                  // Amanda Cooper-Sarkar, Philipp Mertsch, Subir Sarkar. JHEP 08, 042 (2011).
-                  //      f = (-649.265343982+26.4437052803*pow(E,0.296160447336))*1.e-36;
-  
-  // Sarkar model (Yann's parametrization)
-  //    double AS=-0.391641;
-  //    double BS=0.635232;
-  //    double CS=-0.0158144;
-  //    f= (pow(10,AS+BS*log10(E)+CS*pow(log10(E),2)))*1.e-36;
-        
+  if(CCmode == 0){
+      double log10_E_GeV = log10(E);
+      if(!AntiNu){
+          C0 = -1.826;
+          C1 = -17.31;
+          C2 = -6.406;
+          C3 = 1.431;
+          C4 = -17.91;
+      }
       
+      else{
+          C0 = -1.033;
+          C1 = -15.95;
+          C2 = -7.247;
+          C3 = 1.569;
+          C4 = -17.72;
+      }
+      
+      return pow(10, C1 + C2*log(E-C0) + pow(C3*log(E-C0), 2) + C4/log(E-C0));
+  }
+  
+  else{
+      std::cout << "No Parameterization Selected!" << std::endl;
+      return 0;
+  }   
 }
 
 
-double dsigNC(double E, int CCmode, int type,int AntiNu)
+double dsigNC(double E, int CCmode, int type,int AntiNu )
 {
-  double f=0.; 
+  AntiNu=int(abs(AntiNu-1)/2);//return AntiNu to be like a bool
   
+  double C0;
+  double C1;
+  double C2;
+  double C3;
+  double C4;
+  if(CCmode == 0){
+      double log10_E_GeV = log10(E);
+      if(!AntiNu){
+          C0 = -1.826;
+          C1 = -17.31;
+          C2 = -6.448;
+          C3 = 1.431;
+          C4 = -18.61;
+      }
       
-  AntiNu=int(abs(AntiNu-1)/2);//return anti ness as a bool
-  double p[4];
-
-  // The value below determines when we switch from the parameterizations 
-  // of the neutrino cross sections at ultra-high energis (e.g. CTTW standard values) 
-  // to the cross sections to the Ghandi parameterization. These transitions were determined
-  // using the parameterization made for this code. They are likely a bit different if the user 
-  // switches the cross section to the upper or lower cross section models. 
-  
-  double E_switch = 2.00e6;  // GeV
-
-  // If the energy is below E_sigma_switch, set CCmode to the Ghandi cross-section.
-  // If the particle is a neutrino, AntiNu = 0 and the cross-section is set to the
-  // the Ghandi model for neutrinos. If it is an anti-neutrino, AntiNu=1 and the
-  // cross-section is set to the Ghdni model for anti-neutrinos.
-
-  if( E < E_switch ){
-  CCmode = 3 + AntiNu;
-  }
-
-  // Connolly+, 2011 middle model (ARW's parametrization)
-  double p0[4] = { -5.41463399e+01,   2.65465169e+00,  -1.11848922e-01,   1.75469643e-03};
-  // Connolly+, 2011 lower model (ARW's parametrization)
-  double p1[4] = {-4.42377028e+01, 7.07758518e-01, 1.55925146e-02, -1.02484763e-03};
-  // Connolly+, 2011 upper model (ARW's parametrization)
-  double p2[4] = {-5.36713302e+01,   2.72528813e+00,  -1.27067769e-01,   2.31235293e-03};
+      else{
+          C0 = -1.033;
+          C1 = -15.95;
+          C2 = -7.296;
+          C3 = 1.569;
+          C4 = -18.30;
+      }
       
-  // Gandhi, Quigg, Reno 1995 Neutrino cross section
-  double p3[4] = { -6.33753554e+01,   4.26790713e+00,  -2.07426844e-01,   3.68501726e-03};
-  // Gandhi, Quigg, Reno 1995 Anti-Neutrino cross section
-  double p4[4] = { -6.33697437e+01,   4.11592385e+00,  -1.90600183e-01,   3.22478095e-03};
-
-  double log10_E_eV = log10(E)+9.;
-  for (int ii = 0 ; ii<4; ii++){
-    if(CCmode==0) p[ii] = p0[ii];
-    if(CCmode==1) p[ii] = p1[ii];
-    if(CCmode==2) p[ii] = p2[ii];
-    if(CCmode==3) p[ii] = p3[ii];
-    if(CCmode==4) p[ii] = p4[ii];
-
-    f += p[ii]*pow(log10_E_eV,ii);
+      return pow(10, C1 + C2*log(E-C0) + pow(C3*log(E-C0), 2) + C4/log(E-C0));
   }
-
-  f = pow(10,f);
   
-  return f;
+  else{
+      std::cout << "No Parameterization Selected!" << std::endl;
+      return 0;
+  }   
 }
 
 // ###################################################

--- a/Simu_elost.cxx
+++ b/Simu_elost.cxx
@@ -2347,7 +2347,7 @@ double dsigNC(double E, int CCmode, int type,int AntiNu )
   double C4;
   if(CCmode == 0){
       double log10_E_GeV = log10(E);
-      std::cout<<log10_E_GeV<<std::endl;
+      //std::cout<<log10_E_GeV<<std::endl;
       if(!AntiNu){
           C0 = -1.826;
           C1 = -17.31;


### PR DESCRIPTION
Updates CTW cross section to parameterization from paper for each lepton charge. Changes definition of `CCmode == 0` to this parameterization. Older parameterizations are all incremented by 1 (e.g. previous `CCmode=0` ARW parameterization of middle CTW cross section model is now `CCmode=1`).